### PR TITLE
Add user-invocable flag to skills

### DIFF
--- a/.claude/skills/calendar/SKILL.md
+++ b/.claude/skills/calendar/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: calendar
 description: View and manage your Google Calendar. Use for week-at-a-glance views, event color management, and schedule queries. Shows events from ALL authenticated accounts (personal + work).
+user-invocable: true
 ---
 
 # /calendar - Calendar View and Management

--- a/.claude/skills/time-report/SKILL.md
+++ b/.claude/skills/time-report/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: time-report
 description: Generate time analysis reports showing how you spent your week, with gap detection and category breakdowns. Shows data from all authenticated Google accounts.
+user-invocable: true
 ---
 
 # /time-report - Time Analysis & Weekly Reports


### PR DESCRIPTION
## Summary

Mark skills as user-invocable so they can be invoked directly via slash commands (e.g., `/calendar`, `/time-report`).

**Changes:**
- Added `user-invocable: true` to calendar skill
- Added `user-invocable: true` to time-report skill

Without this flag, skills can only be invoked by Claude, not directly by users.

## Test plan

- [ ] Run `/calendar` - should work directly without error
- [ ] Run `/time-report` - should work directly without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)