### PR TITLE
fix(web): restore auth URL pathname after Next basePath strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ If the public URL is **not** the Vercel project root (for example the app appear
 
 **Common mistake:** rewriting to `https://your-app.vercel.app/:path*` (dropping `/app/me-os` on the destination). The browser still loads HTML from `/app/me-os/...`, but relative API calls and assets expect the deployment to be mounted at **`/app/me-os`** on that host. The destination must preserve that prefix, as in the example above. If you intentionally host MeOS at **`https://your.domain/app`** only (no `/me-os`), use `NEXT_PUBLIC_BASE_PATH=/app` and align `AUTH_URL` and rewrites for **`/app`** end-to-end instead—see your site’s `hugo-deploy-plans.md` if you use that shorter pattern.
 
+**OAuth callback 400 (“Bad request.”):** Next.js strips `basePath` from `req.url` inside Route Handlers, while Auth.js is configured with `basePath` `{mount}/api/auth`. The `[...nextauth]` route restores the full pathname before calling Auth so the Google callback can be parsed (see `web/lib/auth-request-url.ts`).
+
 ### Capacitor / iOS simulator (OAuth)
 
 - **`AUTH_URL` / `NEXTAUTH_URL`** must match the **public base URL** of the app (origin **and** path if you use `NEXT_PUBLIC_BASE_PATH`). Google’s redirect URI is **`{AUTH_URL}/api/auth/mobile/google/callback`**. For local dev at the site root, use `http://localhost:3000` when the WebView loads that origin.

--- a/web/__tests__/lib/auth-request-url.test.ts
+++ b/web/__tests__/lib/auth-request-url.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { authPathnameForAuthJs } from "@/lib/auth-request-url";
+
+describe("authPathnameForAuthJs", () => {
+  it("leaves paths unchanged when no Next basePath", () => {
+    expect(authPathnameForAuthJs("/api/auth/callback/google", "")).toBe(
+      "/api/auth/callback/google"
+    );
+  });
+
+  it("prefixes /api/auth when Next uses basePath (stripped from req.url)", () => {
+    expect(
+      authPathnameForAuthJs("/api/auth/callback/google", "/app/me-os")
+    ).toBe("/app/me-os/api/auth/callback/google");
+  });
+
+  it("does not double-prefix", () => {
+    expect(
+      authPathnameForAuthJs(
+        "/app/me-os/api/auth/callback/google",
+        "/app/me-os"
+      )
+    ).toBe("/app/me-os/api/auth/callback/google");
+  });
+});

--- a/web/app/api/auth/[...nextauth]/route.ts
+++ b/web/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,13 @@
 import { handlers } from "@/lib/auth";
+import { restoreAuthRequestUrlForAuthJs } from "@/lib/auth-request-url";
+import type { NextRequest } from "next/server";
 
-export const { GET, POST } = handlers;
+const { GET: authGET, POST: authPOST } = handlers;
+
+export function GET(req: NextRequest) {
+  return authGET(restoreAuthRequestUrlForAuthJs(req));
+}
+
+export function POST(req: NextRequest) {
+  return authPOST(restoreAuthRequestUrlForAuthJs(req));
+}

--- a/web/lib/auth-request-url.ts
+++ b/web/lib/auth-request-url.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from "next/server";
+import { getBasePath } from "./base-path";
+
+/**
+ * Next.js strips `basePath` from `req.url` before App Router handlers run, so Auth.js
+ * sees `/api/auth/...` while `authConfig.basePath` is `{basePath}/api/auth`. That
+ * breaks `parseActionAndProviderId` and yields 400 "Bad request." on OAuth callback.
+ */
+export function authPathnameForAuthJs(
+  pathname: string,
+  nextBasePath: string
+): string {
+  if (!nextBasePath) return pathname;
+  if (pathname.startsWith(`${nextBasePath}/`)) return pathname;
+  if (pathname.startsWith("/api/auth")) {
+    return `${nextBasePath}${pathname}`;
+  }
+  return pathname;
+}
+
+export function restoreAuthRequestUrlForAuthJs(req: NextRequest): NextRequest {
+  const bp = getBasePath();
+  const nextUrl = req.nextUrl.clone();
+  const path = authPathnameForAuthJs(nextUrl.pathname, bp);
+  if (path === nextUrl.pathname) return req;
+  nextUrl.pathname = path;
+  return new NextRequest(nextUrl, req);
+}


### PR DESCRIPTION
Next.js removes basePath from req.url before App Router handlers. Auth.js basePath is /{mount}/api/auth, so parseActionAndProviderId failed on /api/auth/callback/google and returned 400 Bad request.

Wrap [...nextauth] GET/POST to re-prefix pathname when NEXT_PUBLIC_BASE_PATH is set.

Made-with: Cursor