### PR TITLE
feat(web): privacy policy and terms of service routes

### DIFF
--- a/web/app/components/LegalDocument.tsx
+++ b/web/app/components/LegalDocument.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+export function LegalDocument({
+  title,
+  lastUpdated,
+  children,
+}: {
+  title: string;
+  lastUpdated: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+      <header className="border-b border-gray-200 dark:border-gray-800 bg-white/80 dark:bg-gray-950/80 backdrop-blur pt-safe px-4 py-4">
+        <div className="max-w-3xl mx-auto flex flex-wrap items-center justify-between gap-4">
+          <Link
+            href="/login"
+            className="text-sm font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+          >
+            ← Sign in
+          </Link>
+          <nav className="flex gap-4 text-sm text-gray-600 dark:text-gray-400">
+            <Link
+              href="/privacy"
+              className="hover:text-gray-900 dark:hover:text-white"
+            >
+              Privacy
+            </Link>
+            <Link
+              href="/terms"
+              className="hover:text-gray-900 dark:hover:text-white"
+            >
+              Terms
+            </Link>
+          </nav>
+        </div>
+      </header>
+      <main className="max-w-3xl mx-auto px-4 py-10 pb-16">
+        <h1 className="text-3xl font-bold tracking-tight mb-2">{title}</h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-8">
+          Last updated: {lastUpdated}
+        </p>
+        <article className="space-y-6 text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+          {children}
+        </article>
+      </main>
+    </div>
+  );
+}
+
+export function LegalSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="space-y-2">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+        {title}
+      </h2>
+      <div className="space-y-2">{children}</div>
+    </section>
+  );
+}

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,5 +1,6 @@
 import { GoogleSignInShell } from "@/app/components/google-sign-in-shell";
 import { auth, signIn } from "@/lib/auth";
+import Link from "next/link";
 import { redirect } from "next/navigation";
 
 export default async function LoginPage({
@@ -74,6 +75,23 @@ export default async function LoginPage({
         <p className="mt-4 text-center text-xs text-gray-500 dark:text-gray-400">
           By signing in, you agree to connect your Google Calendar for time
           tracking and scheduling features.
+        </p>
+        <p className="text-center text-xs text-gray-500 dark:text-gray-400">
+          <Link
+            href="/privacy"
+            className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 underline-offset-2 hover:underline"
+          >
+            Privacy Policy
+          </Link>
+          <span className="mx-2" aria-hidden>
+            ·
+          </span>
+          <Link
+            href="/terms"
+            className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 underline-offset-2 hover:underline"
+          >
+            Terms of Service
+          </Link>
         </p>
       </div>
     </div>

--- a/web/app/privacy/page.tsx
+++ b/web/app/privacy/page.tsx
@@ -30,8 +30,7 @@ export default function PrivacyPage() {
 
       <LegalSection title="How information is stored">
         <p>
-          The operator’s deployment may store account and session data (for
-          example via a database such as Supabase) to keep you signed in and to
+          The operator’s deployment may store account and session data to keep you signed in and to
           persist preferences, goals, and app-generated content. What is stored
           depends on how the operator configured the deployment.
         </p>

--- a/web/app/privacy/page.tsx
+++ b/web/app/privacy/page.tsx
@@ -1,0 +1,93 @@
+import type { Metadata } from "next";
+import { LegalDocument, LegalSection } from "@/app/components/LegalDocument";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy · MeOS",
+  description: "How MeOS handles your data and Google account access.",
+};
+
+const LAST_UPDATED = "March 26, 2026";
+
+export default function PrivacyPage() {
+  return (
+    <LegalDocument title="Privacy Policy" lastUpdated={LAST_UPDATED}>
+      <p>
+        MeOS (“the application”) is a personal productivity tool. This policy
+        describes how information is handled when you use a deployment of MeOS
+        operated by its owner (“operator”). If you use someone else’s instance,
+        that operator is responsible for how the app is run and may layer
+        additional terms.
+      </p>
+
+      <LegalSection title="Information we access">
+        <p>
+          When you sign in with Google, MeOS may access profile information
+          (such as name and email) and Google Calendar data as authorized by the
+          OAuth scopes you approve. Calendar access is used for scheduling,
+          reporting, and related features shown in the app.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="How information is stored">
+        <p>
+          The operator’s deployment may store account and session data (for
+          example via a database such as Supabase) to keep you signed in and to
+          persist preferences, goals, and app-generated content. What is stored
+          depends on how the operator configured the deployment.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Use of data">
+        <p>
+          Data is used to provide the service: authentication, calendar views,
+          time insights, goals, and other in-app features. MeOS is not intended
+          to sell your personal information. Third parties (such as Google or
+          your hosting provider) process data under their own policies when you
+          use their services.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Retention and deletion">
+        <p>
+          Retention depends on operator configuration and provider tooling. You
+          can revoke MeOS’s access to your Google account in your Google
+          Account permissions. For data held by the operator, contact them to
+          request deletion where applicable.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Security">
+        <p>
+          Reasonable measures such as HTTPS, secure cookies for sign-in, and
+          access controls on backend services are expected in a typical
+          deployment. No method of transmission or storage is completely
+          secure.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Children">
+        <p>
+          MeOS is not directed at children under 13 (or the minimum age required
+          in your jurisdiction). Do not use the service if you do not meet that
+          age requirement.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Changes">
+        <p>
+          This policy may be updated from time to time. The “Last updated” date
+          at the top reflects the latest revision for this deployment’s
+          published page.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Contact">
+        <p>
+          For questions about this policy or this deployment, contact the
+          operator of the site where you are using MeOS (for example via the
+          contact information they publish on their main website).
+        </p>
+      </LegalSection>
+    </LegalDocument>
+  );
+}

--- a/web/app/terms/page.tsx
+++ b/web/app/terms/page.tsx
@@ -1,0 +1,102 @@
+import type { Metadata } from "next";
+import { LegalDocument, LegalSection } from "@/app/components/LegalDocument";
+
+export const metadata: Metadata = {
+  title: "Terms of Service · MeOS",
+  description: "Terms for using the MeOS application.",
+};
+
+const LAST_UPDATED = "March 26, 2026";
+
+export default function TermsPage() {
+  return (
+    <LegalDocument title="Terms of Service" lastUpdated={LAST_UPDATED}>
+      <p>
+        These Terms of Service (“Terms”) govern your use of MeOS (“the
+        application”), a personal productivity tool. By accessing or using the
+        application on an operator’s deployment, you agree to these Terms. If
+        you do not agree, do not use the application.
+      </p>
+
+      <LegalSection title="The service">
+        <p>
+          MeOS is provided “as is” and “as available.” Features may change,
+          pause, or end without notice. The operator may restrict or terminate
+          access at any time.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Your account">
+        <p>
+          You may need a Google account to sign in. You are responsible for
+          safeguarding your account and for activity under your session. You
+          must provide accurate information where requested and comply with
+          Google’s terms when using Google sign-in.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Acceptable use">
+        <p>
+          You agree not to misuse the application—for example, by attempting
+          to gain unauthorized access, disrupt services, scrape in violation of
+          applicable rules, or use the app in violation of law. The operator
+          may suspend use that appears harmful or abusive.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Third-party services">
+        <p>
+          MeOS integrates with Google (and possibly other services the operator
+          enables). Your use of those services is subject to the third party’s
+          terms and privacy policies. MeOS is not responsible for third-party
+          services.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Disclaimer of warranties">
+        <p>
+          To the fullest extent permitted by law, the application is provided
+          without warranties of any kind, whether express or implied, including
+          merchantability, fitness for a particular purpose, and
+          non-infringement. The operator does not warrant uninterrupted or
+          error-free operation.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Limitation of liability">
+        <p>
+          To the fullest extent permitted by law, the operator and contributors
+          are not liable for any indirect, incidental, special, consequential,
+          or punitive damages, or any loss of profits, data, or goodwill,
+          arising from your use of the application. Some jurisdictions do not
+          allow certain limitations; in those jurisdictions, liability is
+          limited to the maximum extent permitted.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Indemnity">
+        <p>
+          To the extent permitted by law, you agree to indemnify and hold
+          harmless the operator from claims arising out of your use of the
+          application or violation of these Terms, except to the extent caused
+          by the operator’s willful misconduct.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Changes">
+        <p>
+          These Terms may be updated. The “Last updated” date at the top
+          indicates when this text was last revised for this page. Continued
+          use after changes constitutes acceptance of the revised Terms.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Contact">
+        <p>
+          For questions about these Terms or this deployment, contact the
+          operator of the site where you are using MeOS.
+        </p>
+      </LegalSection>
+    </LegalDocument>
+  );
+}

--- a/web/app/terms/page.tsx
+++ b/web/app/terms/page.tsx
@@ -28,10 +28,11 @@ export default function TermsPage() {
 
       <LegalSection title="Your account">
         <p>
-          You may need a Google account to sign in. You are responsible for
-          safeguarding your account and for activity under your session. You
-          must provide accurate information where requested and comply with
-          Google’s terms when using Google sign-in.
+          You may need a third-party account, such as a Google account, to fully 
+          benefit from the service. You are responsible for safeguarding your 
+          account and for activity under your session. You must provide accurate
+          information where requested and comply with Google’s terms when using
+          Google sign-in.
         </p>
       </LegalSection>
 

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -7,7 +7,13 @@ import { NextResponse } from "next/server";
 // which breaks session cookies with JWTSessionError / Invalid Compact JWE.
 
 // Routes that don't require authentication
-const publicRoutes = ["/login", "/api/auth", "/api/health"];
+const publicRoutes = [
+  "/login",
+  "/privacy",
+  "/terms",
+  "/api/auth",
+  "/api/health",
+];
 
 // Check if a path matches any public route (pathname includes `basePath` when set)
 function isPublicRoute(pathname: string): boolean {


### PR DESCRIPTION
## Summary

Adds public **Privacy Policy** and **Terms of Service** pages for MeOS (e.g. Google OAuth verification and sign-in transparency).

## Routes

| Path | Purpose |
|------|---------|
| `/privacy` | Privacy policy |
| `/terms` | Terms of service |

With `NEXT_PUBLIC_BASE_PATH=/app/me-os`, public URLs look like:
- `https://www.stephen-weiss.com/app/me-os/privacy`
- `https://www.stephen-weiss.com/app/me-os/terms`

## Implementation

- New shared layout component `web/app/components/LegalDocument.tsx` (header with Sign in + cross-links, last-updated line, sections).
- `web/proxy.ts`: treat `/privacy` and `/terms` as public (no redirect to login).
- `web/app/login/page.tsx`: footer links to both pages.

## Notes

- Copy is written as a reasonable default for a personal/single-operator deployment; the operator should review and adjust contact sections and dates as needed.
- **Last updated** is set to March 26, 2026 on both pages—bump when you edit the text.

## Verification

- `pnpm --filter web test:run`
- `pnpm exec next build` (from `web/`)

Made with [Cursor](https://cursor.com)