### PR TITLE
fix(web): post-login redirect includes /app/me-os base path

### DIFF
--- a/web/__tests__/lib/auth-redirect.test.ts
+++ b/web/__tests__/lib/auth-redirect.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("resolveAuthRedirectUrl", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("joins relative path to origin only when no base path", async () => {
+    vi.unstubAllEnvs();
+    const { resolveAuthRedirectUrl: fn } = await import("@/lib/auth-redirect");
+    expect(fn("/today", "https://example.com")).toBe("https://example.com/today");
+  });
+
+  it("prefixes NEXT_PUBLIC_BASE_PATH for relative URLs", async () => {
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/app/me-os");
+    const { resolveAuthRedirectUrl: fn } = await import("@/lib/auth-redirect");
+    expect(fn("/today", "https://www.example.com")).toBe(
+      "https://www.example.com/app/me-os/today"
+    );
+  });
+
+  it("fixes same-origin absolute URL missing mount", async () => {
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/app/me-os");
+    const { resolveAuthRedirectUrl: fn } = await import("@/lib/auth-redirect");
+    expect(fn("https://www.example.com/today", "https://www.example.com")).toBe(
+      "https://www.example.com/app/me-os/today"
+    );
+  });
+
+  it("leaves same-origin URL unchanged when path already under mount", async () => {
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/app/me-os");
+    const { resolveAuthRedirectUrl: fn } = await import("@/lib/auth-redirect");
+    const url = "https://www.example.com/app/me-os/today?week=1";
+    expect(fn(url, "https://www.example.com")).toBe(url);
+  });
+});

--- a/web/lib/auth-redirect.ts
+++ b/web/lib/auth-redirect.ts
@@ -1,0 +1,36 @@
+import { getBasePath } from "./base-path";
+
+/**
+ * Auth.js passes `baseUrl` as `url.origin` only (see `@auth/core` callback-url),
+ * so relative redirects like `/today` become `https://example.com/today` and lose
+ * `NEXT_PUBLIC_BASE_PATH`. This joins with `origin + basePath` when mounted.
+ */
+export function resolveAuthRedirectUrl(
+  url: string,
+  baseUrlFromAuthJs: string
+): string {
+  const origin = baseUrlFromAuthJs.replace(/\/$/, "");
+  const bp = getBasePath();
+  const appBase = bp ? `${origin}${bp}` : origin;
+
+  if (url.startsWith("/")) {
+    return `${appBase}${url}`;
+  }
+  try {
+    const parsed = new URL(url);
+    const originParsed = new URL(origin);
+    if (parsed.origin !== originParsed.origin) {
+      return appBase;
+    }
+    if (
+      bp &&
+      parsed.pathname !== bp &&
+      !parsed.pathname.startsWith(`${bp}/`)
+    ) {
+      return `${appBase}${parsed.pathname}${parsed.search}${parsed.hash}`;
+    }
+    return url;
+  } catch {
+    return appBase;
+  }
+}

--- a/web/lib/auth.config.ts
+++ b/web/lib/auth.config.ts
@@ -6,6 +6,7 @@
 import type { NextAuthConfig } from "next-auth";
 import Google from "next-auth/providers/google";
 import { SupabaseAdapter } from "@auth/supabase-adapter";
+import { resolveAuthRedirectUrl } from "./auth-redirect";
 import { getAuthJsBasePath } from "./base-path";
 
 const supabaseUrl =
@@ -53,14 +54,7 @@ export const authConfig: NextAuthConfig = {
       return session;
     },
     async redirect({ url, baseUrl }) {
-      const base = baseUrl.replace(/\/$/, "");
-      if (url.startsWith("/")) return `${base}${url}`;
-      try {
-        if (new URL(url).origin === base) return url;
-      } catch {
-        return base;
-      }
-      return base;
+      return resolveAuthRedirectUrl(url, baseUrl);
     },
   },
   pages: {


### PR DESCRIPTION
## Problem

After Google OAuth, users were sent to `https://stephen-weiss.com/today` instead of `https://stephen-weiss.com/app/me-os/today`.

## Cause

`@auth/core` calls the `redirect` callback with `baseUrl: url.origin` only (no path). The previous handler did `${baseUrl}${url}` for relative URLs like `/today`, producing an origin-only base and dropping `NEXT_PUBLIC_BASE_PATH`.

## Fix

- `web/lib/auth-redirect.ts`: `resolveAuthRedirectUrl()` joins relative URLs with `origin + getBasePath()`, and rewrites same-origin absolute URLs whose path is missing the mount.
- `auth.config.ts`: delegate `callbacks.redirect` to that helper.

## Tests

`web/__tests__/lib/auth-redirect.test.ts` — Vitest.

## Verify

`pnpm --filter web test:run` and `next build` (from `web/`).

Made with [Cursor](https://cursor.com)