### PR TITLE
chore(meos): beads issue tracking + task ledger infra, docs update

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,0 +1,72 @@
+# Dolt database (managed by Dolt, not git)
+dolt/
+
+# Runtime files
+bd.sock
+bd.sock.startlock
+sync-state.json
+last-touched
+.exclusive-lock
+
+# Daemon runtime (lock, log, pid)
+daemon.*
+
+# Interactions log (runtime, not versioned)
+interactions.jsonl
+
+# Push state (runtime, per-machine)
+push-state.json
+
+# Lock files (various runtime locks)
+*.lock
+
+# Credential key (encryption key for federation peer auth — never commit)
+.beads-credential-key
+
+# Local version tracking (prevents upgrade notification spam after git ops)
+.local_version
+
+# Worktree redirect file (contains relative path to main repo's .beads/)
+# Must not be committed as paths would be wrong in other clones
+redirect
+
+# Sync state (local-only, per-machine)
+# These files are machine-specific and should not be shared across clones
+.sync.lock
+export-state/
+export-state.json
+
+# Ephemeral store (SQLite - wisps/molecules, intentionally not versioned)
+ephemeral.sqlite3
+ephemeral.sqlite3-journal
+ephemeral.sqlite3-wal
+ephemeral.sqlite3-shm
+
+# Dolt server management (auto-started by bd)
+dolt-server.pid
+dolt-server.log
+dolt-server.lock
+dolt-server.port
+dolt-server.activity
+
+# Corrupt backup directories (created by bd doctor --fix recovery)
+*.corrupt.backup/
+
+# Backup data (auto-exported JSONL, local-only)
+backup/
+
+# Per-project environment file (Dolt connection config, GH#2520)
+.env
+
+# Legacy files (from pre-Dolt versions)
+*.db
+*.db?*
+*.db-journal
+*.db-wal
+*.db-shm
+db.sqlite
+bd.db
+# NOTE: Do NOT add negation patterns here.
+# They would override fork protection in .git/info/exclude.
+# Config files (metadata.json, config.yaml) are tracked by git by default
+# since no pattern above ignores them.

--- a/.beads/README.md
+++ b/.beads/README.md
@@ -1,0 +1,81 @@
+# Beads - AI-Native Issue Tracking
+
+Welcome to Beads! This repository uses **Beads** for issue tracking - a modern, AI-native tool designed to live directly in your codebase alongside your code.
+
+## What is Beads?
+
+Beads is issue tracking that lives in your repo, making it perfect for AI coding agents and developers who want their issues close to their code. No web UI required - everything works through the CLI and integrates seamlessly with git.
+
+**Learn more:** [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
+
+## Quick Start
+
+### Essential Commands
+
+```bash
+# Create new issues
+bd create "Add user authentication"
+
+# View all issues
+bd list
+
+# View issue details
+bd show <issue-id>
+
+# Update issue status
+bd update <issue-id> --claim
+bd update <issue-id> --status done
+
+# Sync with Dolt remote
+bd dolt push
+```
+
+### Working with Issues
+
+Issues in Beads are:
+- **Git-native**: Stored in Dolt database with version control and branching
+- **AI-friendly**: CLI-first design works perfectly with AI coding agents
+- **Branch-aware**: Issues can follow your branch workflow
+- **Always in sync**: Auto-syncs with your commits
+
+## Why Beads?
+
+✨ **AI-Native Design**
+- Built specifically for AI-assisted development workflows
+- CLI-first interface works seamlessly with AI coding agents
+- No context switching to web UIs
+
+🚀 **Developer Focused**
+- Issues live in your repo, right next to your code
+- Works offline, syncs when you push
+- Fast, lightweight, and stays out of your way
+
+🔧 **Git Integration**
+- Automatic sync with git commits
+- Branch-aware issue tracking
+- Dolt-native three-way merge resolution
+
+## Get Started with Beads
+
+Try Beads in your own projects:
+
+```bash
+# Install Beads
+curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+
+# Initialize in your repo
+bd init
+
+# Create your first issue
+bd create "Try out Beads"
+```
+
+## Learn More
+
+- **Documentation**: [github.com/steveyegge/beads/docs](https://github.com/steveyegge/beads/tree/main/docs)
+- **Quick Start Guide**: Run `bd quickstart`
+- **Examples**: [github.com/steveyegge/beads/examples](https://github.com/steveyegge/beads/tree/main/examples)
+
+---
+
+*Beads: Issue tracking that moves at the speed of thought* ⚡

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,54 @@
+# Beads Configuration File
+# This file configures default behavior for all bd commands in this repository
+# All settings can also be set via environment variables (BD_* prefix)
+# or overridden with command-line flags
+
+# Issue prefix for this repository (used by bd init)
+# If not set, bd init will auto-detect from directory name
+# Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
+# issue-prefix: ""
+
+# Use no-db mode: JSONL-only, no Dolt database
+# When true, bd will use .beads/issues.jsonl as the source of truth
+# no-db: false
+
+# Enable JSON output by default
+# json: false
+
+# Feedback title formatting for mutating commands (create/update/close/dep/edit)
+# 0 = hide titles, N > 0 = truncate to N characters
+# output:
+#   title-length: 255
+
+# Default actor for audit trails (overridden by BEADS_ACTOR or --actor)
+# actor: ""
+
+# Export events (audit trail) to .beads/events.jsonl on each flush/sync
+# When enabled, new events are appended incrementally using a high-water mark.
+# Use 'bd export --events' to trigger manually regardless of this setting.
+# events-export: false
+
+# Multi-repo configuration (experimental - bd-307)
+# Allows hydrating from multiple repositories and routing writes to the correct database
+# repos:
+#   primary: "."  # Primary repo (where this database lives)
+#   additional:   # Additional repos to hydrate from (read-only)
+#     - ~/beads-planning  # Personal planning repo
+#     - ~/work-planning   # Work planning repo
+
+# JSONL backup (periodic export for off-machine recovery)
+# Auto-enabled when a git remote exists. Override explicitly:
+# backup:
+#   enabled: false     # Disable auto-backup entirely
+#   interval: 15m      # Minimum time between auto-exports
+#   git-push: false    # Disable git push (export locally only)
+#   git-repo: ""       # Separate git repo for backups (default: project repo)
+
+# Integration settings (access with 'bd config get/set')
+# These are stored in the database, not in this file:
+# - jira.url
+# - jira.project
+# - linear.url
+# - linear.api-key
+# - github.org
+# - github.repo

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,7 @@
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "embedded",
+  "dolt_database": "me_os",
+  "project_id": "b6e5657f-a96b-4742-ace8-7b54d77a6931"
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "command": "bd prime",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "bd prime",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ]
+  }
+}

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run post-merge "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-merge'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-commit'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ supabase/.temp/
 .DS_Store
 Thumbs.db
 
+# Multi-agent orchestration outputs (ledger may be tracked; artifacts are not)
+.tasks/artifacts/
+
 # Editor
 .vscode/
 .idea/
@@ -38,3 +41,8 @@ Thumbs.db
 *.log
 npm-debug.log*
 config/turso.json
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key

--- a/.tasks/README.md
+++ b/.tasks/README.md
@@ -1,0 +1,53 @@
+# Task ledger
+
+Externalized state for multi-agent orchestration (see `.claude/workflows/orchestration.md`).
+
+## Layout
+
+```
+.tasks/
+├── ledger.json           # Orchestration state (commit when it describes a real plan)
+├── ledger.template.json  # Copy to start a new ledger
+├── artifacts/            # Gitignored — agent outputs
+│   ├── architect/
+│   ├── developer/
+│   ├── reviews/
+│   │   ├── staff/
+│   │   ├── dba/
+│   │   ├── typescript/
+│   │   ├── security/
+│   │   └── performance/
+│   ├── qa/
+│   └── tester/
+└── README.md
+```
+
+## Schema
+
+See `ledger.template.json`. Key ideas:
+
+- Each task has `persona`, `status`, optional `workspace` (jj workspace name), optional `artifact` path.
+- The orchestrator updates `ledger.json` on disk; subagents write artifacts under `artifacts/`.
+
+## Review artifact paths (MeOS)
+
+| Persona | Example artifact |
+|---------|------------------|
+| Staff Engineer | `.tasks/artifacts/reviews/staff/rev-staff-001.md` |
+| TypeScript Expert | `.tasks/artifacts/reviews/typescript/rev-ts-001.md` |
+| DBA | `.tasks/artifacts/reviews/dba/rev-dba-001.md` |
+| Security | `.tasks/artifacts/reviews/security/rev-security-001.md` |
+| Performance | `.tasks/artifacts/reviews/performance/rev-perf-001.md` |
+
+## Verification commands (for Tester / Developer)
+
+```bash
+pnpm test
+pnpm --filter web test:run
+```
+
+## See also
+
+- `.claude/personas/README.md`
+- `.claude/workflows/orchestration.md`
+- `.claude/workflows/jj-workflow.md`

--- a/.tasks/ledger.template.json
+++ b/.tasks/ledger.template.json
@@ -1,0 +1,45 @@
+{
+  "version": "1.0",
+  "goal": "Brief description of overall objective",
+  "created": "YYYY-MM-DDTHH:MM:SSZ",
+  "updated": "YYYY-MM-DDTHH:MM:SSZ",
+  "status": "planning",
+  "tasks": [
+    {
+      "id": "arch-001",
+      "description": "Design technical approach",
+      "persona": "architect",
+      "status": "pending",
+      "workspace": null,
+      "artifact": null,
+      "created": "YYYY-MM-DDTHH:MM:SSZ",
+      "completed": null,
+      "dependencies": [],
+      "metadata": {}
+    },
+    {
+      "id": "dev-001",
+      "description": "Implement per architecture",
+      "persona": "developer",
+      "status": "pending",
+      "workspace": "ai-feature-name",
+      "artifact": null,
+      "created": "YYYY-MM-DDTHH:MM:SSZ",
+      "completed": null,
+      "dependencies": ["arch-001"],
+      "metadata": {}
+    },
+    {
+      "id": "rev-staff-001",
+      "description": "Review implementation",
+      "persona": "staff-engineer",
+      "status": "pending",
+      "workspace": null,
+      "artifact": null,
+      "created": "YYYY-MM-DDTHH:MM:SSZ",
+      "completed": null,
+      "dependencies": ["dev-001"],
+      "metadata": {}
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ A skill is a set of local instructions stored in a `SKILL.md` file. Use these en
 - `weekly-goals`: Set, track, and review weekly goals in MeOS (database / web) with progress tracking and non-goal alerts. (file: `/Users/sweiss/code/me-os/.claude/skills/weekly-goals/SKILL.md`)
 - `time-report`: Weekly/daily time analysis with gap detection and interactive categorization. (file: `/Users/sweiss/code/me-os/.claude/skills/time-report/SKILL.md`)
 - `one-on-one`: Process and summarize 1:1 notes from voice, images, files, or text. (file: `/Users/sweiss/code/me-os/.claude/skills/one-on-one/SKILL.md`)
+- `jj-workspace`: Isolated jj workspace for parallel human or sub-agent workstreams; amend discipline and handoff. (file: `.claude/skills/jj-workspace/SKILL.md`)
+- `orchestrate`: Persona-based multi-agent flow with `.tasks/ledger.json`, review gate, and ledger shell helpers. (file: `.claude/skills/orchestrate/SKILL.md`)
 
 ### Skill trigger and usage rules
 
@@ -61,7 +63,12 @@ me-os/
 │   ├── calendar-manager/# Active conflict/category/flex management
 │   ├── calendar-optimizer/ # Goal-based optimization
 │   ├── time-report/    # Weekly time analysis and gap detection
-│   └── one-on-one/     # 1:1 note processing and reporting
+│   ├── one-on-one/     # 1:1 note processing and reporting
+│   ├── jj-workspace/   # Jujutsu workspace workflow for isolated work
+│   └── orchestrate/    # Persona orchestration + task ledger helpers
+├── .claude/personas/   # Role prompts for subagent orchestration
+├── .claude/workflows/  # planning.md, jj-workflow.md, orchestration.md
+├── .tasks/             # Optional ledger + gitignored artifacts for multi-agent runs
 ├── mcp/                # MCP server implementations
 │   └── google-calendar/# Google Calendar MCP server
 ├── docs/superpowers/
@@ -176,6 +183,18 @@ Requires `jj git init --colocate` at repo root (already done for this repo). Cre
 cd ../worktrees/me-os/<workspace-name>
 ```
 
+Sub-agent / parallel workstream (prefixes `ai-` automatically):
+
+```bash
+./scripts/jj-workspace-start.sh --agent <short-name>
+cd ../worktrees/me-os/ai-<short-name>
+jj new trunk() -m "Summary"
+```
+
+**Jj repo config (workspace names in log, `jj ls` / `jj stack` / `jj amend` aliases):** run once per clone: `./scripts/jj-setup-config.sh`
+
+**Full jj + agent rules:** `.claude/workflows/jj-workflow.md` — **isolated work skill:** `.claude/skills/jj-workspace/SKILL.md`
+
 When finished: `./scripts/jj-workspace-done.sh <workspace-name>`
 
 ### Publishing a jj workspace to GitHub (bookmark → PR)
@@ -194,6 +213,25 @@ For work you do mainly in a **jj workspace**, use a **jj bookmark** as the Git b
 If `jj git push` refuses, fetch and fix bookmark conflicts per [jj bookmark push safety](https://docs.jj-vcs.dev/latest/bookmarks/#pushing-bookmarks-safety-checks). After a rebase or history rewrite, the push may **move** the remote bookmark sideways (jj uses checks similar to `--force-with-lease`).
 
 *Example:* workspace `capacitor-ios` with bookmark `sw-capacitor-ios-phase1` for the native shell line—same pattern applies to any feature bookmark.
+
+## Multi-agent development (jj)
+
+When multiple agents (or you + agents) work in parallel, use **separate jj workspaces** so each has its own working copy. Agents should follow `.claude/skills/jj-workspace/SKILL.md`: `jj new trunk()`, `jj amend`, no bookmark/push unless you ask.
+
+**You monitor:** `lazyjj` or `watch -n 1 --color jj log` from your main checkout.
+
+**You harvest:** `jj new <agent-change-id>`, verify with `pnpm test`, then bookmark/PR as usual.
+
+**Cleanup:** `./scripts/jj-workspace-done.sh ai-<name>`
+
+## Subagent orchestration
+
+For persona-based multi-agent work (Architect → Developer → review gate → QA → Tester), use **`.claude/skills/orchestrate/SKILL.md`** and `.claude/workflows/orchestration.md`.
+
+- Initialize or update **`.tasks/ledger.json`**; shell helpers: `source .claude/skills/orchestrate/ledger-helpers.sh`
+- Outputs under **`.tasks/artifacts/`** (gitignored — see `.tasks/README.md`)
+- Pass **file paths** between steps, not inlined contents
+- **superpowers:subagent-driven-development** complements this repo’s personas under `.claude/personas/`
 
 ### Setting Up Local Testing
 
@@ -257,3 +295,50 @@ Skills are invoked via Claude Code:
 - `/calendar-optimizer` - Optimize schedule against goals
 - `/time-report` - Generate time analysis
 - `/one-on-one [name]` - Process 1:1 notes
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd dolt push
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->


### PR DESCRIPTION
## Summary

Part 3 of 3 in the MeOS tooling stack. Adds shared infrastructure for issue tracking and multi-agent task coordination, plus the CLAUDE.md documentation that ties the whole stack together.

- **`.beads/`** — beads repo init (`config.yaml`, `metadata.json`, `README.md`, `.gitignore`). Runtime artifacts (`.local_version`, `backup/`, `embeddeddolt/`, `push-state.json`, `interactions.jsonl`, `.beads-credential-key`) are gitignored.
- **`.claude/settings.json`** — `bd prime` hooks on `SessionStart` and `PreCompact` so new sessions / post-compaction auto-load beads context.
- **`.githooks/pre-commit`, `post-merge`** — keep beads Dolt store in sync with the git repo.
- **`.tasks/README.md`, `ledger.template.json`** — multi-agent task ledger scaffolding. `.tasks/artifacts/` is gitignored.
- **`.gitignore`** — ignore `.tasks/artifacts/`, `.dolt/`, `*.db`, `.beads-credential-key`.
- **`CLAUDE.md`** — document the two new skills (`jj-workspace`, `orchestrate`), the `.claude/personas/` and `.claude/workflows/` layout, the multi-agent (jj) + subagent orchestration sections, and the beads issue tracker integration (including the session-completion push protocol).

Builds on top of `sw-meos-workflow`.

## Stack

1. `sw-meos-personas` — personas (base: `main`) → #110
2. `sw-meos-workflow` — workflow tooling (base: `sw-meos-personas`) → #111
3. **this PR** — beads + tasks + docs (base: `sw-meos-workflow`)

## Test plan

- [ ] `bd prime` runs via `SessionStart` hook in a fresh Claude Code session
- [ ] Pre-commit / post-merge hooks fire without errors
- [ ] CLAUDE.md renders correctly and all referenced paths exist
- [ ] `AGENTS.md` symlink still resolves to the updated `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)