### PR TITLE
chore(personas): complete staff-engineer verdict vocabulary alignment

### DIFF
--- a/.claude/personas/staff-engineer.md
+++ b/.claude/personas/staff-engineer.md
@@ -37,5 +37,5 @@ Your output naturally takes this form — the orchestrator may override format:
 
 - Invoke after Developer, and optionally after Architect (for design review)
 - Pass implementation artifact and requirements/architecture as inputs
-- A `revise` or `reject` verdict should loop back to Developer before proceeding
+- A `concerns` or `blocking issues` verdict feeds back to Developer before proceeding
 - Output feeds into: Developer (if revisions needed), QA Engineer, release gate


### PR DESCRIPTION
## Summary

Follow-up to [PR #110](https://github.com/stephencweiss/me-os/pull/110). The review-response commit there ([`8f816102`](https://github.com/stephencweiss/me-os/commit/8f816102)) updated the Verdict list in `staff-engineer.md` to `clear / concerns / blocking issues` but missed the loop-back sentence in **Orchestrator Notes**, which still referenced the prior `revise` / `reject` verdicts.

This aligns the loop-back rule with the canonical vocabulary so the ledger parsing in the forthcoming `orchestrate` skill sees one shape across every review persona (Staff Engineer, TypeScript Expert, DBA, Security Reviewer, Performance Specialist).

## Test plan

- [ ] Render `.claude/personas/staff-engineer.md` — Verdict list (line 30) and Orchestrator Notes loop-back rule (line 40) use the same vocabulary
- [ ] `grep -n "revise\|reject" .claude/personas/staff-engineer.md` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)